### PR TITLE
fix: adminDivison4 for kailahun district

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this
 file. This file is structured according to http://keepachangelog.com/
 
 - - -
+## 3.1.2 27.10.2015
+
+###Fixed
+- corrected locations with parentId '11-15' refering to unexistant parent
+
 ## 3.1.1 14.10.2015
 
 Note that this version is not breaking, because version 3.1 did not

--- a/history/sierra_leone/add_sections_localities_admin_divisions/Readme.md
+++ b/history/sierra_leone/add_sections_localities_admin_divisions/Readme.md
@@ -35,7 +35,7 @@ match the already present id in the json/sierra_leone.json file.
 changes:
 - bo:  exchange `bagbe` and `bagbo`
 - bobmali: added dummy line for `bombali sebora`
-- kailahun :  put kissi tongi after kissi teng
+- kailahun :  put kissi tongi after kissi teng. Fix mispell error in the source: Corrected Kisis Tongi to Kissi Tongi
 - kambia: exchange `bramaia` with `gbinle dixin`
 - koinadugu NOTE making `dembelia musaia` === `folosaba dembelia` see comments in https://github.com/eHealthAfrica/sl-ebola-call-admin/issues/959
 - pujehun  Kpanga - Kabonde  moved after `Mano Sakrim`. `Futa Pejeh` moved after `Panga Krim`

--- a/history/sierra_leone/add_sections_localities_admin_divisions/sources/kailahun_village.csv
+++ b/history/sierra_leone/add_sections_localities_admin_divisions/sources/kailahun_village.csv
@@ -253,97 +253,97 @@ Kissi Teng,Torli,Kayia
 Kissi Teng,Torli,Fodadu
 Kissi Teng,Torli,Kolobengu
 Kissi Teng,Torli,Kpangbenin
-Kisis Tongi,Konio,Sakao
-Kisis Tongi,Konio,Kondoma
-Kisis Tongi,Konio,Kamapodu
-Kisis Tongi,Konio,Sumdu
-Kisis Tongi,Konio,Saama
-Kisis Tongi,Konio,Fandu
-Kisis Tongi,Konio,Tongoma
-Kisis Tongi,Konio,Tedu
-Kisis Tongi,Konio,Kpokpoma
-Kisis Tongi,Konio,Leparlo
-Kisis Tongi,Konio,Koikor
-Kisis Tongi,Konio,Bandama
-Kisis Tongi,Konio,Levuma
-Kisis Tongi,Konio,Sumbadu
-Kisis Tongi,Konio,Dambara
-Kisis Tongi,Konio,Kabala
-Kisis Tongi,Konio,Banda-Bengu
-Kisis Tongi,Konio,Falama
-Kisis Tongi,Konio,Fenesu
-Kisis Tongi,Konio,Kpongbondu
-Kisis Tongi,Konio,Makor
-Kisis Tongi,Konio,Torkpombu
-Kisis Tongi,Konio,Ngokodu
-Kisis Tongi,Konio,Bumbeto
-Kisis Tongi,Konio,Buedu
-Kisis Tongi,Konio,Kpetema
-Kisis Tongi,Konio,Pyoto
-Kisis Tongi,Konio,Kundowahun
-Kisis Tongi,Pokorli,Kanilo
-Kisis Tongi,Pokorli,Nafadu
-Kisis Tongi,Pokorli,Kodupombor
-Kisis Tongi,Pokorli,Bendu
-Kisis Tongi,Pokorli,Bamba
-Kisis Tongi,Pokorli,Grima
-Kisis Tongi,Pokorli,Krigbema
-Kisis Tongi,Pokorli,Kualeni
-Kisis Tongi,Pokorli,Kodu-Bendu
-Kisis Tongi,Pokorli,Kpelu
-Kisis Tongi,Pokorli,Sardu-Pambor
-Kisis Tongi,Pokorli,Fuadu
-Kisis Tongi,Pokorli,Weh
-Kisis Tongi,Pokorli,Sondokoro Lolobengu
-Kisis Tongi,Pokorli,Kamadu
-Kisis Tongi,Pokorli,Baladu
-Kisis Tongi,Pokorli,Boidu
-Kisis Tongi,Pokorli,Bedu
-Kisis Tongi,Pokorli,Mano
-Kisis Tongi,Pokorli,Wondor
-Kisis Tongi,Pokorli,Mendekelema
-Kisis Tongi,Tongi - Tingi,Kpangadu
-Kisis Tongi,Tongi - Tingi,Kondewadu
-Kisis Tongi,Tongi - Tingi,Bedu
-Kisis Tongi,Tongi - Tingi,Kongbama
-Kisis Tongi,Tongi - Tingi,Kundukoro
-Kisis Tongi,Tongi - Tingi,Leparlo
-Kisis Tongi,Tongi - Tingi,Koikor
-Kisis Tongi,Tongi - Tingi,Dawa
-Kisis Tongi,Tongi - Tingi,Fangamadu
-Kisis Tongi,Tongi - Tingi,Senga
-Kisis Tongi,Tongi - Tingi,Makpadu
-Kisis Tongi,Tongi - Tingi,voahun
-Kisis Tongi,Tongi - Tingi,Tambiyama
-Kisis Tongi,Tongi - Tingi,Poluma
-Kisis Tongi,Tongi - Tingi,Bombodu
-Kisis Tongi,Tongi - Tingi,Sewadu
-Kisis Tongi,Tongi - Tingi,Benduma
-Kisis Tongi,Tongi - Tingi,Gbalama
-Kisis Tongi,Tongi - Tingi,Vamesu
-Kisis Tongi,Tongi - Tingi,Konia
-Kisis Tongi,Tongi - Tingi,Koindu - Combey
-Kisis Tongi,Tongi - Tingi,Kolahun
-Kisis Tongi,Tongi - Tingi,Bambesu
-Kisis Tongi,Tongi - Tingi,Mamboma
-Kisis Tongi,Tongi - Tingi,Kabadu
-Kisis Tongi,Tongi - Tingi,Kamadu
-Kisis Tongi,Tongi - Tingi,Sunga
-Kisis Tongi,Tongi - Tingi,Kpakutahun
-Kisis Tongi,Tongi - Tingi,Kolu
-Kisis Tongi,Tongi - Tingi,Sanga
-Kisis Tongi,Tongi - Tingi,Tambatekor
-Kisis Tongi,Tongi - Tingi,Bayama
-Kisis Tongi,Tongi - Tingi,Baoma
-Kisis Tongi,Tongi - Tingi,Nyandeyama
-Kisis Tongi,Tongi - Tingi,Dambalu
-Kisis Tongi,Tongi - Tingi,Kanga
-Kisis Tongi,Tongi - Tingi,Gbandiwulo
-Kisis Tongi,Tongi - Tingi,Mano
-Kisis Tongi,Tongi - Tingi,Kpekedu
-Kisis Tongi,Tongi - Tingi,Ngolahun
-Kisis Tongi,Tongi - Tingi,Gordilahun
-Kisis Tongi,Tongi - Tingi,Njalonda
+Kissi Tongi,Konio,Sakao
+Kissi Tongi,Konio,Kondoma
+Kissi Tongi,Konio,Kamapodu
+Kissi Tongi,Konio,Sumdu
+Kissi Tongi,Konio,Saama
+Kissi Tongi,Konio,Fandu
+Kissi Tongi,Konio,Tongoma
+Kissi Tongi,Konio,Tedu
+Kissi Tongi,Konio,Kpokpoma
+Kissi Tongi,Konio,Leparlo
+Kissi Tongi,Konio,Koikor
+Kissi Tongi,Konio,Bandama
+Kissi Tongi,Konio,Levuma
+Kissi Tongi,Konio,Sumbadu
+Kissi Tongi,Konio,Dambara
+Kissi Tongi,Konio,Kabala
+Kissi Tongi,Konio,Banda-Bengu
+Kissi Tongi,Konio,Falama
+Kissi Tongi,Konio,Fenesu
+Kissi Tongi,Konio,Kpongbondu
+Kissi Tongi,Konio,Makor
+Kissi Tongi,Konio,Torkpombu
+Kissi Tongi,Konio,Ngokodu
+Kissi Tongi,Konio,Bumbeto
+Kissi Tongi,Konio,Buedu
+Kissi Tongi,Konio,Kpetema
+Kissi Tongi,Konio,Pyoto
+Kissi Tongi,Konio,Kundowahun
+Kissi Tongi,Pokorli,Kanilo
+Kissi Tongi,Pokorli,Nafadu
+Kissi Tongi,Pokorli,Kodupombor
+Kissi Tongi,Pokorli,Bendu
+Kissi Tongi,Pokorli,Bamba
+Kissi Tongi,Pokorli,Grima
+Kissi Tongi,Pokorli,Krigbema
+Kissi Tongi,Pokorli,Kualeni
+Kissi Tongi,Pokorli,Kodu-Bendu
+Kissi Tongi,Pokorli,Kpelu
+Kissi Tongi,Pokorli,Sardu-Pambor
+Kissi Tongi,Pokorli,Fuadu
+Kissi Tongi,Pokorli,Weh
+Kissi Tongi,Pokorli,Sondokoro Lolobengu
+Kissi Tongi,Pokorli,Kamadu
+Kissi Tongi,Pokorli,Baladu
+Kissi Tongi,Pokorli,Boidu
+Kissi Tongi,Pokorli,Bedu
+Kissi Tongi,Pokorli,Mano
+Kissi Tongi,Pokorli,Wondor
+Kissi Tongi,Pokorli,Mendekelema
+Kissi Tongi,Tongi - Tingi,Kpangadu
+Kissi Tongi,Tongi - Tingi,Kondewadu
+Kissi Tongi,Tongi - Tingi,Bedu
+Kissi Tongi,Tongi - Tingi,Kongbama
+Kissi Tongi,Tongi - Tingi,Kundukoro
+Kissi Tongi,Tongi - Tingi,Leparlo
+Kissi Tongi,Tongi - Tingi,Koikor
+Kissi Tongi,Tongi - Tingi,Dawa
+Kissi Tongi,Tongi - Tingi,Fangamadu
+Kissi Tongi,Tongi - Tingi,Senga
+Kissi Tongi,Tongi - Tingi,Makpadu
+Kissi Tongi,Tongi - Tingi,voahun
+Kissi Tongi,Tongi - Tingi,Tambiyama
+Kissi Tongi,Tongi - Tingi,Poluma
+Kissi Tongi,Tongi - Tingi,Bombodu
+Kissi Tongi,Tongi - Tingi,Sewadu
+Kissi Tongi,Tongi - Tingi,Benduma
+Kissi Tongi,Tongi - Tingi,Gbalama
+Kissi Tongi,Tongi - Tingi,Vamesu
+Kissi Tongi,Tongi - Tingi,Konia
+Kissi Tongi,Tongi - Tingi,Koindu - Combey
+Kissi Tongi,Tongi - Tingi,Kolahun
+Kissi Tongi,Tongi - Tingi,Bambesu
+Kissi Tongi,Tongi - Tingi,Mamboma
+Kissi Tongi,Tongi - Tingi,Kabadu
+Kissi Tongi,Tongi - Tingi,Kamadu
+Kissi Tongi,Tongi - Tingi,Sunga
+Kissi Tongi,Tongi - Tingi,Kpakutahun
+Kissi Tongi,Tongi - Tingi,Kolu
+Kissi Tongi,Tongi - Tingi,Sanga
+Kissi Tongi,Tongi - Tingi,Tambatekor
+Kissi Tongi,Tongi - Tingi,Bayama
+Kissi Tongi,Tongi - Tingi,Baoma
+Kissi Tongi,Tongi - Tingi,Nyandeyama
+Kissi Tongi,Tongi - Tingi,Dambalu
+Kissi Tongi,Tongi - Tingi,Kanga
+Kissi Tongi,Tongi - Tingi,Gbandiwulo
+Kissi Tongi,Tongi - Tingi,Mano
+Kissi Tongi,Tongi - Tingi,Kpekedu
+Kissi Tongi,Tongi - Tingi,Ngolahun
+Kissi Tongi,Tongi - Tingi,Gordilahun
+Kissi Tongi,Tongi - Tingi,Njalonda
 Kissi Tongi,Bende Bengu,Bandenin
 Kissi Tongi,Bende Bengu,Kpaama
 Kissi Tongi,Bende Bengu,Sandia

--- a/json/sierra_leone.json
+++ b/json/sierra_leone.json
@@ -2995,9 +2995,9 @@
         "parentId": "11-05"
       },
       {
-        "id": "11-06-01",
+        "id": "11-05-01",
         "name": "bende bengu",
-        "parentId": "11-06"
+        "parentId": "11-05"
       },
       {
         "id": "11-07-01",
@@ -3035,259 +3035,259 @@
         "parentId": "11-07"
       },
       {
-        "id": "11-08-01",
+        "id": "11-07-01",
         "name": "bunjumbu",
+        "parentId": "11-07"
+      },
+      {
+        "id": "11-07-02",
+        "name": "golama",
+        "parentId": "11-07"
+      },
+      {
+        "id": "11-07-03",
+        "name": "kpawa",
+        "parentId": "11-07"
+      },
+      {
+        "id": "11-07-04",
+        "name": "kpindima",
+        "parentId": "11-07"
+      },
+      {
+        "id": "11-07-05",
+        "name": "seimaya",
+        "parentId": "11-07"
+      },
+      {
+        "id": "11-08-01",
+        "name": "baoma",
         "parentId": "11-08"
       },
       {
         "id": "11-08-02",
-        "name": "golama",
+        "name": "gao",
         "parentId": "11-08"
       },
       {
         "id": "11-08-03",
-        "name": "kpawa",
+        "name": "gbela",
         "parentId": "11-08"
       },
       {
         "id": "11-08-04",
-        "name": "kpindima",
+        "name": "giehun",
         "parentId": "11-08"
       },
       {
         "id": "11-08-05",
-        "name": "seimaya",
+        "name": "lower kpombali",
+        "parentId": "11-08"
+      },
+      {
+        "id": "11-08-06",
+        "name": "luawa foguiya",
+        "parentId": "11-08"
+      },
+      {
+        "id": "11-08-07",
+        "name": "mafindor",
+        "parentId": "11-08"
+      },
+      {
+        "id": "11-08-08",
+        "name": "mano sewallu",
+        "parentId": "11-08"
+      },
+      {
+        "id": "11-08-09",
+        "name": "mende -buima",
+        "parentId": "11-08"
+      },
+      {
+        "id": "11-08-10",
+        "name": "upper kpombali",
         "parentId": "11-08"
       },
       {
         "id": "11-09-01",
-        "name": "baoma",
+        "name": "bamburu",
         "parentId": "11-09"
       },
       {
         "id": "11-09-02",
-        "name": "gao",
+        "name": "lower sami",
         "parentId": "11-09"
       },
       {
         "id": "11-09-03",
-        "name": "gbela",
+        "name": "njagbla",
         "parentId": "11-09"
       },
       {
         "id": "11-09-04",
-        "name": "giehun",
+        "name": "pelegbambeima",
         "parentId": "11-09"
       },
       {
         "id": "11-09-05",
-        "name": "lower kpombali",
-        "parentId": "11-09"
-      },
-      {
-        "id": "11-09-06",
-        "name": "luawa foguiya",
-        "parentId": "11-09"
-      },
-      {
-        "id": "11-09-07",
-        "name": "mafindor",
-        "parentId": "11-09"
-      },
-      {
-        "id": "11-09-08",
-        "name": "mano sewallu",
-        "parentId": "11-09"
-      },
-      {
-        "id": "11-09-09",
-        "name": "mende -buima",
-        "parentId": "11-09"
-      },
-      {
-        "id": "11-09-10",
-        "name": "upper kpombali",
+        "name": "upper sami",
         "parentId": "11-09"
       },
       {
         "id": "11-10-01",
-        "name": "bamburu",
+        "name": "gbongre",
         "parentId": "11-10"
       },
       {
         "id": "11-10-02",
-        "name": "lower sami",
+        "name": "levuma jeigbla",
         "parentId": "11-10"
       },
       {
         "id": "11-10-03",
-        "name": "njagbla",
+        "name": "lower kuiva",
         "parentId": "11-10"
       },
       {
         "id": "11-10-04",
-        "name": "pelegbambeima",
-        "parentId": "11-10"
-      },
-      {
-        "id": "11-10-05",
-        "name": "upper sami",
+        "name": "upper kuiva",
         "parentId": "11-10"
       },
       {
         "id": "11-11-01",
-        "name": "gbongre",
+        "name": "bombowa",
         "parentId": "11-11"
       },
       {
         "id": "11-11-02",
-        "name": "levuma jeigbla",
+        "name": "dan - sei",
         "parentId": "11-11"
       },
       {
         "id": "11-11-03",
-        "name": "lower kuiva",
+        "name": "falley",
         "parentId": "11-11"
       },
       {
         "id": "11-11-04",
-        "name": "upper kuiva",
+        "name": "fauya",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-05",
+        "name": "gbao",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-06",
+        "name": "jonga",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-07",
+        "name": "kargbu",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-08",
+        "name": "keimaya",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-09",
+        "name": "lower nyawa",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-10",
+        "name": "sei",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-11",
+        "name": "sei ii",
+        "parentId": "11-11"
+      },
+      {
+        "id": "11-11-12",
+        "name": "upper nyawo",
         "parentId": "11-11"
       },
       {
         "id": "11-12-01",
-        "name": "bombowa",
+        "name": "bulima",
         "parentId": "11-12"
       },
       {
         "id": "11-12-02",
-        "name": "dan - sei",
+        "name": "jagor",
         "parentId": "11-12"
       },
       {
         "id": "11-12-03",
-        "name": "falley",
+        "name": "kumantandu",
         "parentId": "11-12"
       },
       {
         "id": "11-12-04",
-        "name": "fauya",
+        "name": "lombama",
         "parentId": "11-12"
       },
       {
         "id": "11-12-05",
-        "name": "gbao",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-06",
-        "name": "jonga",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-07",
-        "name": "kargbu",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-08",
-        "name": "keimaya",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-09",
-        "name": "lower nyawa",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-10",
-        "name": "sei",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-11",
-        "name": "sei ii",
-        "parentId": "11-12"
-      },
-      {
-        "id": "11-12-12",
-        "name": "upper nyawo",
+        "name": "nimima",
         "parentId": "11-12"
       },
       {
         "id": "11-13-01",
-        "name": "bulima",
+        "name": "bambara",
         "parentId": "11-13"
       },
       {
         "id": "11-13-02",
-        "name": "jagor",
+        "name": "goleiwoma",
         "parentId": "11-13"
       },
       {
         "id": "11-13-03",
-        "name": "kumantandu",
+        "name": "golu",
         "parentId": "11-13"
       },
       {
         "id": "11-13-04",
-        "name": "lombama",
+        "name": "guma bomaru",
         "parentId": "11-13"
       },
       {
         "id": "11-13-05",
-        "name": "nimima",
+        "name": "korbu",
+        "parentId": "11-13"
+      },
+      {
+        "id": "11-13-06",
+        "name": "niahun",
         "parentId": "11-13"
       },
       {
         "id": "11-14-01",
-        "name": "bambara",
+        "name": "bendu",
         "parentId": "11-14"
       },
       {
         "id": "11-14-02",
-        "name": "goleiwoma",
+        "name": "kuiva buima",
         "parentId": "11-14"
       },
       {
         "id": "11-14-03",
-        "name": "golu",
+        "name": "kuiva jagor",
         "parentId": "11-14"
       },
       {
         "id": "11-14-04",
-        "name": "guma bomaru",
-        "parentId": "11-14"
-      },
-      {
-        "id": "11-14-05",
-        "name": "korbu",
-        "parentId": "11-14"
-      },
-      {
-        "id": "11-14-06",
-        "name": "niahun",
-        "parentId": "11-14"
-      },
-      {
-        "id": "11-15-01",
-        "name": "bendu",
-        "parentId": "11-15"
-      },
-      {
-        "id": "11-15-02",
-        "name": "kuiva buima",
-        "parentId": "11-15"
-      },
-      {
-        "id": "11-15-03",
-        "name": "kuiva jagor",
-        "parentId": "11-15"
-      },
-      {
-        "id": "11-15-04",
         "name": "kuivawa",
-        "parentId": "11-15"
+        "parentId": "11-14"
       },
       {
         "id": "12-01-01",


### PR DESCRIPTION
Source file for adding adminDivision 4 for kailahun village
had a typo, and both a correct and wrong version, which genearted
one too many parents. The added adminDivison4 were pointing to
an inexisiting parent id "11-15"

This pr corrects the source and the locations file